### PR TITLE
Update rpc_wrapper.py

### DIFF
--- a/cryptokit/rpc_wrapper.py
+++ b/cryptokit/rpc_wrapper.py
@@ -176,7 +176,7 @@ class CoinRPC(object):
 
     @rpc_conn
     def unlock_wallet(self, seconds=10):
-        if self.wallet_pass:
+        if self.config.has_key('wallet_pass'):
             try:
                 wallet = self.conn.walletpassphrase(self.wallet_pass, seconds)
             except CoinRPCException as e:
@@ -197,7 +197,7 @@ class CoinRPC(object):
         """
 
         # Coerce all amounts to float
-        for k, amount in recip.values():
+        for k, amount in recip.items():
             recip[k] = float(amount)
 
         self.unlock_wallet()


### PR DESCRIPTION
recip is a data struct like {addr0:amount0, addr1:amount1,...}, so recip.values should be [amount0, amount1,...], and this will trigger TypeError: 'float' object is not iterable

if no wallet_pass in config and call self.wallet_pass will triggle KeyError
